### PR TITLE
feat: add hackathon management features and error handling pages

### DIFF
--- a/manager-app/build.gradle
+++ b/manager-app/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/manager-app/src/main/java/org/hackit/space/managerapp/controller/HackathonController.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/controller/HackathonController.java
@@ -1,0 +1,81 @@
+package org.hackit.space.managerapp.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.hackit.space.managerapp.controller.payload.UpdateHackathonPayload;
+import org.hackit.space.managerapp.entity.Hackathon;
+import org.hackit.space.managerapp.service.HackathonService;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Locale;
+import java.util.NoSuchElementException;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("hackathons/{hackathonId:\\d+}")
+public class HackathonController {
+
+    private final HackathonService hackathonService;
+
+    private final MessageSource messageSource;
+
+    @ModelAttribute("hackathon")
+    public Hackathon hackathon(@PathVariable("hackathonId") int hackathonId) {
+        return this.hackathonService.findHackathon(hackathonId)
+                .orElseThrow(() -> new NoSuchElementException("errors.hackathon.not_found"));
+    }
+
+    @GetMapping
+    public String getHackathon() {
+        return "hackathons/hackathon";
+    }
+
+    @GetMapping("edit")
+    public String getHackathonEditPage() {
+        return "hackathons/edit";
+    }
+
+    @PostMapping("edit")
+    public String updateHackathon(@ModelAttribute(value = "hackathon", binding = false) Hackathon hackathon,
+                                  @Valid UpdateHackathonPayload payload,
+                                  BindingResult bindingResult,
+                                  Model model) {
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("payload", payload);
+            model.addAttribute("errors", bindingResult.getAllErrors().stream()
+                    .map(ObjectError::getDefaultMessage)
+                    .toList());
+            return "hackathons/edit";
+        } else {
+            this.hackathonService.updateHackathon(hackathon.getId(), payload.title(), payload.description());
+            return "redirect:/hackathons/%d".formatted(hackathon.getId());
+        }
+    }
+
+    @PostMapping("delete")
+    public String deleteHackathon(@ModelAttribute("hackathon") Hackathon hackathon) {
+        this.hackathonService.deleteHackathon(hackathon.getId());
+        return "redirect:/hackathons/list";
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public String handleNoSuchElementException(NoSuchElementException exception,
+                                               Model model,
+                                               HttpServletResponse response,
+                                               Locale locale) {
+        response.setStatus(HttpStatus.NOT_FOUND.value());
+        model.addAttribute("error",
+                this.messageSource.getMessage(exception.getMessage(),
+                        new Object[0],
+                        exception.getMessage(),
+                        locale));
+        return "errors/404";
+    }
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/controller/HackathonsController.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/controller/HackathonsController.java
@@ -1,0 +1,49 @@
+package org.hackit.space.managerapp.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.hackit.space.managerapp.controller.payload.NewHackathonPayload;
+import org.hackit.space.managerapp.entity.Hackathon;
+import org.hackit.space.managerapp.service.HackathonService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("hackathons")
+public class HackathonsController {
+
+    private final HackathonService hackathonService;
+
+    @GetMapping("list")
+    public String getHackathonsList(Model model) {
+        model.addAttribute("hackathons", this.hackathonService.findAllHackathons());
+        return "hackathons/list";
+    }
+
+    @GetMapping("create")
+    public String getNewHackathonPage() {
+        return "hackathons/new_hackathon";
+    }
+
+    @PostMapping("create")
+    public String createHackathon(@Valid NewHackathonPayload payload,
+                                  BindingResult bindingResult,
+                                  Model model) {
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("payload", payload);
+            model.addAttribute("errors", bindingResult.getAllErrors().stream()
+                    .map(ObjectError::getDefaultMessage)
+                    .toList());
+            return "hackathons/new_hackathon";
+        } else {
+            Hackathon hackathon = hackathonService.createHackathon(payload.title(), payload.description());
+            return "redirect:/hackathons/%d".formatted(hackathon.getId());
+        }
+    }
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/controller/payload/NewHackathonPayload.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/controller/payload/NewHackathonPayload.java
@@ -1,0 +1,13 @@
+package org.hackit.space.managerapp.controller.payload;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record NewHackathonPayload(
+        @NotNull(message = "{hackathons.create.errors.title_is_null}")
+        @Size(min = 3, max = 50, message = "{hackathons.create.errors.title_size_is_invalid}")
+        String title,
+        @Size(max = 1000, message = "{hackathons.create.errors.description_size_is_invalid}")
+        String description
+) {
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/controller/payload/UpdateHackathonPayload.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/controller/payload/UpdateHackathonPayload.java
@@ -1,0 +1,13 @@
+package org.hackit.space.managerapp.controller.payload;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateHackathonPayload(
+        @NotNull(message = "{hackathons.update.errors.title_is_null}")
+        @Size(min = 3, max = 50, message = "{hackathons.update.errors.title_size_is_invalid}")
+        String title,
+        @Size(max = 1000, message = "{hackathons.update.errors.description_size_is_invalid}")
+        String description
+) {
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/entity/Hackathon.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/entity/Hackathon.java
@@ -1,0 +1,18 @@
+package org.hackit.space.managerapp.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hackathon {
+
+    private Integer id;
+
+    private String title;
+
+    private String description;
+
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/repository/HackathonRepository.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/repository/HackathonRepository.java
@@ -1,0 +1,16 @@
+package org.hackit.space.managerapp.repository;
+
+import org.hackit.space.managerapp.entity.Hackathon;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HackathonRepository {
+    List<Hackathon> findAll();
+
+    Hackathon save(Hackathon hackathon);
+
+    Optional<Hackathon> findById(int hackathonId);
+
+    void deleteById(Integer id);
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/repository/InMemoryHackathonRepository.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/repository/InMemoryHackathonRepository.java
@@ -1,0 +1,38 @@
+package org.hackit.space.managerapp.repository;
+
+import org.hackit.space.managerapp.entity.Hackathon;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public class InMemoryHackathonRepository implements HackathonRepository {
+
+    private final List<Hackathon> hackathons = Collections.synchronizedList(new LinkedList<>());
+
+    @Override
+    public List<Hackathon> findAll() {
+        return Collections.unmodifiableList(hackathons);
+    }
+
+    @Override
+    public Hackathon save(Hackathon hackathon) {
+        hackathon.setId(this.hackathons.stream().max(Comparator.comparingInt(Hackathon::getId))
+                .map(Hackathon::getId)
+                .orElse(0) + 1);
+        this.hackathons.add(hackathon);
+        return hackathon;
+    }
+
+    @Override
+    public Optional<Hackathon> findById(int hackathonId) {
+        return this.hackathons.stream()
+                .filter(hackathon -> Objects.equals(hackathonId, hackathon.getId()))
+                .findFirst();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        this.hackathons.removeIf(hackathon -> Objects.equals(id, hackathon.getId()));
+    }
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/service/DefaultHackathonService.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/service/DefaultHackathonService.java
@@ -1,0 +1,48 @@
+package org.hackit.space.managerapp.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hackit.space.managerapp.entity.Hackathon;
+import org.hackit.space.managerapp.repository.HackathonRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultHackathonService implements HackathonService {
+
+    private final HackathonRepository hackathonRepository;
+
+    @Override
+    public List<Hackathon> findAllHackathons() {
+        return hackathonRepository.findAll();
+    }
+
+    @Override
+    public Hackathon createHackathon(String title, String description) {
+        return this.hackathonRepository.save(new Hackathon(null, title, description));
+    }
+
+    @Override
+    public Optional<Hackathon> findHackathon(int hackathonId) {
+        return this.hackathonRepository.findById(hackathonId);
+    }
+
+    @Override
+    public void updateHackathon(Integer id, String title, String description) {
+        this.hackathonRepository.findById(id)
+                .ifPresentOrElse(hackathon -> {
+                    hackathon.setTitle(title);
+                    hackathon.setDescription(description);
+                }, () -> {
+                    throw new NoSuchElementException();
+                });
+    }
+
+    @Override
+    public void deleteHackathon(Integer id) {
+        this.hackathonRepository.deleteById(id);
+    }
+}

--- a/manager-app/src/main/java/org/hackit/space/managerapp/service/HackathonService.java
+++ b/manager-app/src/main/java/org/hackit/space/managerapp/service/HackathonService.java
@@ -1,0 +1,18 @@
+package org.hackit.space.managerapp.service;
+
+import org.hackit.space.managerapp.entity.Hackathon;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HackathonService {
+    List<Hackathon> findAllHackathons();
+
+    Hackathon createHackathon(String title, String description);
+
+    Optional<Hackathon> findHackathon(int hackathonId);
+
+    void updateHackathon(Integer id, String title, String description);
+
+    void deleteHackathon(Integer id);
+}

--- a/manager-app/src/main/resources/application.properties
+++ b/manager-app/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=manager-app

--- a/manager-app/src/main/resources/application.yaml
+++ b/manager-app/src/main/resources/application.yaml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: manager-app
+  profiles:
+    active:
+      - docker
+      - k8s
+      - other

--- a/manager-app/src/main/resources/messages.properties
+++ b/manager-app/src/main/resources/messages.properties
@@ -1,0 +1,12 @@
+errors.hackathon.not_found=Hackathon not found
+
+errors.404.title=Nothing not found in hackathons
+errors.404.header=Error 404: Nothing not found in hackathons
+
+hackathons.create.errors.title_is_null=Title is required
+hackathons.create.errors.title_size_is_invalid=Title size mus be between {min} and {max} characters
+hackathons.create.errors.description_size_is_invalid=Description size must be no more {max} characters
+
+hackathons.update.errors.title_is_null=Title is required
+hackathons.update.errors.title_size_is_invalid=Title size mus be between {min} and {max} characters
+hackathons.update.errors.description_size_is_invalid=Description size must be no more {max} characters

--- a/manager-app/src/main/resources/static/index.html
+++ b/manager-app/src/main/resources/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Manager page</title>
+</head>
+<body>
+<h1>Manager page</h1>
+</body>
+</html>

--- a/manager-app/src/main/resources/templates/errors/404.html
+++ b/manager-app/src/main/resources/templates/errors/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title data-th-text="#{'errors.404.title'}"></title>
+</head>
+<body>
+<h1 data-th-text="#{'errors.404.header'}"></h1>
+<h2 data-th-text="${error}"></h2>
+</body>
+</html>

--- a/manager-app/src/main/resources/templates/hackathons/edit.html
+++ b/manager-app/src/main/resources/templates/hackathons/edit.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit [[${hackathon.title}]] hackathon</title>
+</head>
+<body>
+<a data-th-href="@{/hackathons/{hackathonId}(hackathonId=${hackathon.id})}">To hackathon</a>
+<h1>Edit [[${hackathon.title}]] hackathon</h1>
+<div data-th-if="${errors}">
+    <h2>Fix errors</h2>
+    <ul>
+        <li data-th-each="error: ${errors}" data-th-text="${error}"></li>
+    </ul>
+</div>
+
+<form data-th-action="@{/hackathons/{hackathonId}/edit(hackathonId=${hackathon.id})}" method="post">
+    <label>
+        Title:<br>
+        <input type="text" name="title" data-th-value="${payload != null ? payload.title : hackathon.title}">
+    </label>
+    <label>
+        Description:<br>
+        <textarea name="description" data-th-text="${payload != null ? payload.description : hackathon.description}"></textarea>
+    </label><br>
+    <button type="submit">Edit</button>
+</form>
+</body>
+</html>

--- a/manager-app/src/main/resources/templates/hackathons/hackathon.html
+++ b/manager-app/src/main/resources/templates/hackathons/hackathon.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>[[${hackathon.title}]]</title>
+</head>
+<body>
+<a data-th-href="@{/hackathons/list}">&larr; Hackathons list</a>
+<h1 data-th-text="${hackathon.title}"></h1>
+<ul>
+    <li><strong>ID</strong>: <span data-th-text="${hackathon.id}"></span></li>
+    <li><strong>Title</strong>: <span data-th-text="${hackathon.title}"></span></li>
+    <li><strong>Description</strong>: <span data-th-text="${hackathon.description}"></span></li>
+</ul>
+<a data-th-href="@{/hackathons/{hackathonId}/edit(hackathonId=${hackathon.id})}">Edit</a>
+<form method="post" data-th-action="@{/hackathons/{hackathonId}/delete(hackathonId=${hackathon.id})}">
+    <button type="submit">Delete</button>
+</form>
+</body>
+</html>

--- a/manager-app/src/main/resources/templates/hackathons/list.html
+++ b/manager-app/src/main/resources/templates/hackathons/list.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hackathons list</title>
+</head>
+<body>
+<a data-th-href="@{/hackathons/create}">Create hackathon</a>
+<h1>Hackathons list</h1>
+<table>
+    <thead>
+    <tr>
+        <th>#</th>
+        <th>Hackathon</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr data-th-each="hackathon : ${hackathons}">
+        <td data-th-text="${hackathon.id}"></td>
+        <td>
+            <a data-th-href="@{/hackathons/{hackathonId}(hackathonId=${hackathon.id})}"
+               data-th-text="${hackathon.title}"></a>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/manager-app/src/main/resources/templates/hackathons/new_hackathon.html
+++ b/manager-app/src/main/resources/templates/hackathons/new_hackathon.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>New hackathon</title>
+</head>
+<body>
+<a data-th-href="@{/hackathons/list}">&larr; Hackathons list</a>
+<h1>New hackathon</h1>
+<div data-th-if="${errors}">
+    <h2>Fix errors</h2>
+    <ul>
+        <li data-th-each="error: ${errors}" data-th-text="${error}"></li>
+    </ul>
+</div>
+<form data-th-action="@{/hackathons/create}" method="post">
+    <label>
+        Title:<br>
+        <input type="text" name="title" data-th-value="${payload?.title}">
+    </label>
+    <label>
+        Description:<br>
+        <textarea name="description" data-th-text="${payload?.description}"></textarea>
+    </label><br>
+    <button type="submit">Create</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
- Implement DefaultHackathonService and HackathonService interface for CRUD operations.
- Create Hackathon entity and repository for data management.
- Develop HackathonController and HackathonsController for handling web requests.
- Add HTML templates for displaying, editing, and creating hackathons.
- Introduce custom 404 error page and validation messages.
- Convert application.properties to application.yaml and add Spring profiles.
- Include Spring Boot validation starter dependency in build.gradle.